### PR TITLE
Fixed issue, where you can't clear the chat

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -99,7 +99,7 @@ mongo.connect(DB_URL, {useNewUrlParser: true}, function (err, db) {
     });
 
     socket.on('clear', function (data) {
-      let deleteOne = chat.deleteOne({}, function () {
+      let deleteMany = chat.deleteMany({}, function () {
         socket.emit('cleared');
       });
     });


### PR DESCRIPTION
Fixed the issue, where the clear button only deletes one chat message, by replacing deleteOne() with deleteMany() (issue #23).

Closes #23